### PR TITLE
Add prompt-driven OCR mask generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
 
   <main>
     <section class="controls">
+      <input id="prompt" class="prompt" value="Remove the text and numbers from the upper right of the image" />
+
       <label class="btn">
         <input id="modelInput" type="file" accept=".onnx" />
         Choose LaMa model (.onnx)
@@ -53,8 +55,9 @@
 
   <pre id="log" class="log"></pre>
 
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
   <script type="module">
-    import { initLamaFromBuffer, setExecutionProviders, inpaintUpperRightOne, setLogger, setAssumeBGR } from '/js/lama.js';
+    import { initLamaFromBuffer, setExecutionProviders, inpaintUpperRightOne, setLogger, setAssumeBGR, maskUpperRightViaOCR } from '/js/lama.js';
     import { uiInit, setModelLabel, setBusy, wireImagePicker } from '/js/app.js';
 
     const statusEl   = document.getElementById('status');
@@ -73,7 +76,7 @@
       ort.env.wasm.numThreads = Math.max(2, (navigator.hardwareConcurrency || 8) >> 1);
     }
 
-    uiInit({ inpaintOne: inpaintUpperRightOne, statusEl });
+    uiInit({ inpaintOne: inpaintUpperRightOne, statusEl, maskBuilder: maskUpperRightViaOCR });
     wireImagePicker();
 
     const filesInput = document.getElementById('fileInput');

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@ h1{ font-size:18px; margin:0 0 6px; }
 main{ padding:16px 24px; }
 
 .controls{ display:flex; gap:12px; align-items:center; flex-wrap:wrap; margin-bottom:16px; }
+.prompt{ min-width:420px; padding:8px 10px; border:1px solid var(--line); border-radius:8px; background:#0e1117; color:var(--fg); }
 .btn{ display:inline-flex; align-items:center; gap:8px; border:1px dashed var(--line); padding:8px 12px; border-radius:8px; cursor:pointer; background:#0e1117; }
 .btn input{ display:none; }
 .primary{ background:var(--accent); color:white; border:0; padding:9px 14px; border-radius:8px; cursor:pointer; font-weight:600; }


### PR DESCRIPTION
## Summary
- add a prompt field to the UI, load tesseract.js, and pass the OCR mask builder into the processing pipeline
- implement an OCR-driven upper-right mask generator with dilation and fallback to the legacy rectangle mask
- make image processing prompt-aware so matching prompts trigger OCR detection before inpainting

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5ccaa775c8323ad36df3e0125e75a